### PR TITLE
chore: sync bindings and add drift CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - run: npx tree-sitter init --update
       - name: Check for drift
         run: |
+          # setup.py oscillates between two templates on each init --update run (upstream bug)
+          git checkout -- setup.py
           if ! git diff --exit-code; then
             echo "::error::Bindings are out of sync with tree-sitter.json. Run 'tree-sitter init --update' locally and commit the result."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
       - run: npx tree-sitter init --update
       - name: Check for drift
         run: |
-          # setup.py oscillates between two templates on each init --update run (upstream bug)
-          git checkout -- setup.py
           if ! git diff --exit-code; then
             echo "::error::Bindings are out of sync with tree-sitter.json. Run 'tree-sitter init --update' locally and commit the result."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  bindings-in-sync:
+    name: Bindings in sync with tree-sitter.json
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          cache: npm
+          node-version: "22"
+      - run: npm i --omit peer --omit optional
+      - run: npx tree-sitter init --update
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Bindings are out of sync with tree-sitter.json. Run 'tree-sitter init --update' locally and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
Follow-up to [#15](https://github.com/caffeinelabs/tree-sitter-motoko/pull/15).

Bindings had drifted from `tree-sitter.json` — `tree-sitter init --update` is the source of truth for all generated files (`package.json`, Python/Rust/Node/Swift bindings, Makefile, CMake). Running it applies pending upstream migrations: ESM for Node, `wasm32` target and dynamic query support for Rust, Python free-threading support.

A new CI job (`bindings-in-sync`) catches future drift by re-running `tree-sitter init --update` on every PR and failing if anything changes.

Made with [Cursor](https://cursor.com)